### PR TITLE
Fix zenoh router config

### DIFF
--- a/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
+++ b/DEFAULT_RMW_ZENOH_ROUTER_CONFIG.json5
@@ -40,8 +40,6 @@
     ///
     /// See https://docs.rs/zenoh/latest/zenoh/config/struct.EndPoint.html
     endpoints: [
-      "serial//dev/ttyAMA3#baudrate=1000000",
-      "tcp/0.0.0.0:7447"
     ],
 
     /// Global connect configuration,
@@ -90,7 +88,8 @@
     ///
     /// See https://docs.rs/zenoh/latest/zenoh/config/struct.EndPoint.html
     endpoints: [
-      "tcp/[::]:7447"
+      "serial//dev/ttyAMA3#baudrate=1000000",
+      "tcp/0.0.0.0:7447"
     ],
 
     /// Global listen configuration,

--- a/DEFAULT_RMW_ZENOH_ROUTER_CONFIG_pi4.json5
+++ b/DEFAULT_RMW_ZENOH_ROUTER_CONFIG_pi4.json5
@@ -40,8 +40,6 @@
     ///
     /// See https://docs.rs/zenoh/latest/zenoh/config/struct.EndPoint.html
     endpoints: [
-      "serial//dev/ttyAMA0#baudrate=1000000",
-      "tcp/0.0.0.0:7447"
     ],
 
     /// Global connect configuration,
@@ -90,7 +88,8 @@
     ///
     /// See https://docs.rs/zenoh/latest/zenoh/config/struct.EndPoint.html
     endpoints: [
-      "tcp/[::]:7447"
+      "serial//dev/ttyAMA0#baudrate=1000000",
+      "tcp/0.0.0.0:7447"
     ],
 
     /// Global listen configuration,

--- a/DEFAULT_RMW_ZENOH_ROUTER_CONFIG_pi5.json5
+++ b/DEFAULT_RMW_ZENOH_ROUTER_CONFIG_pi5.json5
@@ -40,8 +40,6 @@
     ///
     /// See https://docs.rs/zenoh/latest/zenoh/config/struct.EndPoint.html
     endpoints: [
-      "serial//dev/ttyAMA3#baudrate=1000000",
-      "tcp/0.0.0.0:7447"
     ],
 
     /// Global connect configuration,
@@ -90,7 +88,8 @@
     ///
     /// See https://docs.rs/zenoh/latest/zenoh/config/struct.EndPoint.html
     endpoints: [
-      "tcp/[::]:7447"
+      "serial//dev/ttyAMA3#baudrate=1000000",
+      "tcp/0.0.0.0:7447"
     ],
 
     /// Global listen configuration,


### PR DESCRIPTION
Fixes configuration for RMW Zenoh router. 

Addresses are moved under `listen` section.